### PR TITLE
proper loading of page

### DIFF
--- a/app/client/js/controllers/index-controller.js
+++ b/app/client/js/controllers/index-controller.js
@@ -1,5 +1,5 @@
-angular.module('linksupp').controller('indexController', ['$scope', '$location', 'userService',
-	function ($scope, $location, userService) {
+angular.module('linksupp').controller('indexController', ['$scope', '$location', 'userService', '$rootScope',
+	function ($scope, $location, userService, $rootScope) {
 		/* GLOBAL DATA START */
 
 		$scope.mealBuddyRequests = [];
@@ -94,12 +94,14 @@ angular.module('linksupp').controller('indexController', ['$scope', '$location',
 		// This allows the initial redirect when they come to the
 		// page based on whether or not they are logged in
 		$scope.init = function() {
-			if ($scope.user == null) {
-				$location.path('login').replace();
-			}
-			else {
-				$location.path('main').replace();
-			}
+			setTimeout(function() {
+				if ($location.path() == '/login' || $location.path() == '/main') {
+					return;
+				}
+				$rootScope.$apply(function() {
+					$location.path('login').replace();
+				});
+			}, 2500);
 		}
 		$scope.init();
 
@@ -199,8 +201,8 @@ angular.module('linksupp').controller('indexController', ['$scope', '$location',
 						if (data.length > 0) {  // Returning user who has already logged in with facebook
 							var userData = data[0];
 							$scope.user = angular.toJson(userData);
-							
-						} 
+							$location.path('main').replace();
+						}
 						else {  // User is logging in to facebook for the first time
 							// MODAL CALL
 							$('#userInformationModal').modal();
@@ -218,11 +220,17 @@ angular.module('linksupp').controller('indexController', ['$scope', '$location',
 				// ie. change the page to the map.
 			}
 			else if (response.status === 'not_authorized') {
-				// The person is logged into Facebook, but not your app.
+				// The person is logged into Facebook, but not your app
+				$rootScope.$apply(function() {
+					$location.path('login').replace();
+				});
 			}
 			else {
 				// The person is not logged into Facebook, so we're not sure if
 				// they are logged into this app or not.
+				$rootScope.$apply(function() {
+					$location.path('login').replace();
+				});
 			}
 		}
 


### PR DESCRIPTION
in this pull request, it now waits for the facebook api call to return 'connected' or 'not connected', and loads the proper page depending on that. we might possibly want a 'loading' screen or text. to test:
1. Be logged into Facebook, reload the page. Unless Facebook is being slow, it should take you to the map page without hitting the login page. If Facebook is being slow, it'll load the login page in 2.5 seconds.
2. Be logged out of Facebook in the app, reload the page. It should take you to the login page.
3. Be logged out of Facebook completely (in your browser, just go incognito). It should take you to the login page.
