### PR TITLE
fixed so that the currently decaying meal is not 'isTomorrow'

### DIFF
--- a/app/client/js/controllers/main-controller.js
+++ b/app/client/js/controllers/main-controller.js
@@ -394,10 +394,8 @@ angular.module('linksupp').controller('mainController', ['$scope', '$location', 
 			mealTime.setMinutes(mealTime.getMinutes()+15);
 			if (currentTime > mealTime) {
 				$scope.timeDay = "Tomorrow at:";
-				// $scope.isTomorrow = true;
 			} else {
 				$scope.timeDay = "Today at:";
-				// $scope.isTomorrow = false;
 			}
 		});
 


### PR DESCRIPTION
To test:
Have a meal created at a time (e.g. 8pm)
After the time has passed (e.g. 8:01pm), the meal should no longer be showing as 'tomorrow'
